### PR TITLE
run_all.sh exits on first test failed

### DIFF
--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -36,7 +36,7 @@ run_test()
     py.test --btcroot="${bitcoind_dir}" --btcpwd=123456abcdef --btcconf="$1" --runtype="$2" -s | tee ${curtest}/pytest.log
     test_result="${PIPESTATUS[0]}"
     echo "${test_result}"
-    if (( ${test_result} != 0 )) && (( ${exit_on_fail} == 1 )); then
+    if (( ${test_result} != 0 )); then
         exit 1
     fi
 }
@@ -86,7 +86,7 @@ main()
         "cnobroadcasttx1" "cbadreceivesecret" "cbadsendtx5sig" "cbadreceivetx4sig")
     local recovery_tests=( rc{3..9} ra{3..11} )
 
-    local bitcoind_="${1:-$(which bitcoind)}" exit_on_fail="0"
+    local bitcoind_="${1:-$(which bitcoind)}"
     echo "using bitcoind : ${bitcoind_}" 2>&1
     if [[ ! -x ${bitcoind_} ]]; then
         echo "bitcoind not found or not executable : ${bitcoind_}" 1>&2
@@ -111,9 +111,6 @@ main()
 
     mk_bitcoinconf "${tmpdir}"
     mk_coinswapconf "${tmpdir}"
-    if [[ -z "$@" ]]; then
-        exit_on_fail="1"
-    fi
     local test_queue=( $( test_case "$@") )
     for test_case in ${test_queue[@]}; do
         curtest="${tmpdir}/${test_case}_${RANDOM}"


### PR DESCRIPTION
Original behavior was to only exit on a failed test if no command line arguments were passed to `run_all.sh`.  This change will make it exit on the first failure even when arguments are used.